### PR TITLE
Travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: python
+python:
+    - "2.7"
+    - "3.4"
+
+install:
+  - pip install .
+
+services:
+  - docker
+
+before_install:
+  - docker pull enkeys/alpine-openjdk-amq7-snapshot
+  - docker run -d -p 5672:5672 enkeys/alpine-openjdk-amq7-snapshot amq7-server
+  - docker ps -a
+
+script:
+  - python tests/test_integration.py


### PR DESCRIPTION
Included docker container with AMQ 7.0 broker build
  - Opened ports
    - 5672 (AMQP)

Tests running with python
  - 2.7
  - 3.4

Resolve #2   