### PR TITLE
UPD(formatter) replace null bytes in output with '\\0' placeholders

### DIFF
--- a/cli_proton_python/formatter.py
+++ b/cli_proton_python/formatter.py
@@ -140,7 +140,7 @@ class Formatter(object):
         :rtype: str
         """
         if isinstance(in_data, bytes):
-            in_data = in_data.decode()
+            in_data = in_data.replace(b'\0', b'\\0').decode()
         int_res = "'%s'" % (Formatter.quote_string_escape(in_data))
         return int_res
 


### PR DESCRIPTION
Python refuses to eval strings with \0 bytes in them, which is breaking
interop tests (the test will not read message from the cli).

    TypeError: expected string without null bytes

Removing the null bytes fixes the problem.