### PR TITLE
FIX(ErrorsHandler): Zero error-code was returned when user was not va…

### DIFF
--- a/cli_proton_python/coreclient.py
+++ b/cli_proton_python/coreclient.py
@@ -381,7 +381,8 @@ class ErrorsHandler(object):  # pylint: disable=too-few-public-methods
                 and event.connection.remote_condition):
             err_message = "Connection error: %s ..." \
                           % self._evaluate_endpoint_error(event.connection, "connection")
-            if self.conn_reconnect == "false":
+            if ("AMQ119031" in err_message
+                    or self.conn_reconnect == "false"):
                 raise ClientException(err_message)
             else:
                 utils.dump_error(err_message)


### PR DESCRIPTION
…lidated on broker

~~
Cause:
  Unhandled case when username and/or password is missing in broker URL,
  for example: user:@host:port/address.
Consequence:
  It looked that client ended without error.
Fix:
  Raise exception when user is not validated on broker side.
Result:
  Exception is raised and client ends with non-zero code.
~~
Relates:
  Closes #39 issue