### PR TITLE
FIX(Urls): Class Urls is not exported from _reactor.py to reactor.py in Qpid Proton Python

### DIFF
--- a/cli_proton_python/coreclient.py
+++ b/cli_proton_python/coreclient.py
@@ -73,7 +73,7 @@ class CoreClient(proton.handlers.MessagingHandler):
             if not isinstance(self.opts.conn_urls, (str, list)):
                 raise ValueError('Invalid conn-urls value, expected string or list: %s'
                                  % self.opts.conn_urls)
-            conn_opts['urls'] = proton._reactor.Urls(self.opts.conn_urls)
+            conn_opts['urls'] = self.opts.conn_urls
         if self.opts.conn_reconnect == 'false':
             conn_opts['reconnect'] = False
         elif (self.opts.conn_reconnect_interval

--- a/cli_proton_python/coreclient.py
+++ b/cli_proton_python/coreclient.py
@@ -73,7 +73,7 @@ class CoreClient(proton.handlers.MessagingHandler):
             if not isinstance(self.opts.conn_urls, (str, list)):
                 raise ValueError('Invalid conn-urls value, expected string or list: %s'
                                  % self.opts.conn_urls)
-            conn_opts['urls'] = proton.reactor.Urls(self.opts.conn_urls)
+            conn_opts['urls'] = proton._reactor.Urls(self.opts.conn_urls)
         if self.opts.conn_reconnect == 'false':
             conn_opts['reconnect'] = False
         elif (self.opts.conn_reconnect_interval


### PR DESCRIPTION
…tor.py in Qpid Proton Python

Relates:
  PROTON-1997 [Python] Urls class is not exported by reactor