### PR TITLE
FIX: catch all exceptions from connector threads

### DIFF
--- a/cli_proton_python/connector.py
+++ b/cli_proton_python/connector.py
@@ -205,7 +205,7 @@ def run_connectors(opts, results, errors, stats=None):
             super(proton.reactor.Container, container).global_handler.add(
                 coreclient.ErrorsHandler(opts.conn_reconnect))
             container.run()
-        except coreclient.ClientException as exc:
+        except (coreclient.ClientException, Exception) as exc:
             simple_connector.result['connection']['error'] = 1
             errors.append(str(exc))
     finally:


### PR DESCRIPTION
Previously, exceptions other than `coreclient.ClientException`
were only logged to stderr, but the error result was not updated,
so the client ended with return code 0 even if there were errors.